### PR TITLE
Fix crash when system isn't already known to EDSM

### DIFF
--- a/edsm.py
+++ b/edsm.py
@@ -47,7 +47,7 @@ class EDSM:
             r.raise_for_status()
             data = r.json()
 
-            if data == -1:
+            if data == -1 or (isinstance(data, list) and len(data) == 0):
                 # System not present - but don't create it on the assumption that the caller will
                 self.result['img'] = EDSM._IMG_NEW
                 self.result['uncharted'] = True
@@ -82,7 +82,7 @@ class EDSM:
             r.raise_for_status()
             data = r.json()
 
-            if data == -1:
+            if data == -1 or (isinstance(data, list) and len(data) == 0):
                 # System not present - create it
                 result['img'] = EDSM._IMG_NEW
                 result['uncharted'] = True


### PR DESCRIPTION
EDSM api is now returning "[]" instead of "-1" when the system name doesn't exist in its database. Fixes "Can't connect to EDSM" errors when jumping to a new system.