### PR TITLE
Add requirements file for use with pip

### DIFF
--- a/requirements
+++ b/requirements
@@ -1,0 +1,6 @@
+argh==0.26.2
+pathtools==0.1.2
+PyYAML==3.12
+requests==2.11.1
+watchdog==0.8.3
+wheel==0.24.0


### PR DESCRIPTION
To make development easier on others, requirements freezes the dependancies for edmc and then someone else can use ` pip install -r requirements`