### PR TITLE
Fix of Czech translation of "Transparent"

### DIFF
--- a/L10n/cs.strings
+++ b/L10n/cs.strings
@@ -449,7 +449,7 @@
 "Trailblazer" = "Trailblazer";
 
 /* Appearance theme setting. [prefs.py] */
-"Transparent" = "Průhledná";
+"Transparent" = "Průhledné";
 
 /* Trade rank. [stats.py] */
 "Tycoon" = "Tycoon";


### PR DESCRIPTION
Could not find this translation in OneSkyApp, so I did it this way.