### PR TITLE
Remove erroneous newline from Russian translation file

### DIFF
--- a/L10n/ru.strings
+++ b/L10n/ru.strings
@@ -470,8 +470,7 @@
 "Theme" = "Тема";
 
 /* Help text in settings. [prefs.py] */
-"Tip: You can disable a plugin by{CR}adding '{EXT}' to it's folder name" = "Подсказка:
-Отключить расширение можно {CR}добавив '{EXT}' к имени папки";
+"Tip: You can disable a plugin by{CR}adding '{EXT}' to it's folder name" = "Подсказка: Отключить расширение можно {CR}добавив '{EXT}' к имени папки";
 
 /* Ranking. [stats.py] */
 "Trade" = "Торговый";


### PR DESCRIPTION
This newline would cause the regex at l10n.py:66 to fail, leading to attempting to print the translation message at l10n.py:70. Since the translation message contains unicode characters, the print would fail which would cause the entire settings window to silently fail loading. There is an error message but the message doesn't appear to be fatal. Since the settings window fails to load, user credentials cannot be updated which may lead to the "Invalid Credentials" error. This is what's been happening to me and I have no idea why other people aren't encountering this bug.