### PR TITLE
Strip bad filename parts from ship names

### DIFF
--- a/edshipyard.py
+++ b/edshipyard.py
@@ -14,6 +14,8 @@ from config import config
 import companion
 import outfitting
 from monitor import monitor
+from filenames import slugify
+
 
 # Map API ship names to E:D Shipyard ship names
 ship_map = dict(companion.ship_map)
@@ -157,10 +159,9 @@ def export(data, filename=None):
                 return	# same as last time - don't write
 
     # Write
-    filename = join(config.get('outdir'), '%s.%s.txt' % (ship, time.strftime('%Y-%m-%dT%H.%M.%S', time.localtime(querytime))))
+    filename = join(config.get('outdir'), '%s.%s.txt' % (slugify(ship), time.strftime('%Y-%m-%dT%H.%M.%S', time.localtime(querytime))))
     with open(filename, 'wt') as h:
         h.write(string)
-
 
 # Return a URL for the current ship
 def url(is_beta):

--- a/filenames.py
+++ b/filenames.py
@@ -1,0 +1,9 @@
+"Functions to handle filenames responsibly."
+
+import re
+
+def slugify(shipname):
+    "Remove or transform parts of a ship name likely to hurt a filename."
+    sanitised = re.sub(r'[^\w\s-]', '', shipname)
+    consolidated = re.sub(r'[-\s]+', '-', sanitised)
+    return consolidated

--- a/loadout.py
+++ b/loadout.py
@@ -6,6 +6,7 @@ import time
 
 from config import config
 import companion
+from filenames import slugify
 
 
 # Export ship loadout in Companion API json format
@@ -30,6 +31,6 @@ def export(data, filename=None):
     querytime = config.getint('querytime') or int(time.time())
 
     # Write
-    filename = join(config.get('outdir'), '%s.%s.txt' % (ship, time.strftime('%Y-%m-%dT%H.%M.%S', time.localtime(querytime))))
+    filename = join(config.get('outdir'), '%s.%s.txt' % (slugify(ship), time.strftime('%Y-%m-%dT%H.%M.%S', time.localtime(querytime))))
     with open(filename, 'wt') as h:
         h.write(string)

--- a/monitor.py
+++ b/monitor.py
@@ -8,6 +8,7 @@ from os.path import basename, isdir, join
 from sys import platform
 from time import gmtime, localtime, sleep, strftime, strptime, time
 from calendar import timegm
+from filenames import slugify
 
 if __debug__:
     from traceback import print_exc
@@ -744,7 +745,7 @@ class EDLogs(FileSystemEventHandler):
                     return	# same as last time - don't write
 
         # Write
-        filename = join(config.get('outdir'), '%s.%s.txt' % (ship, strftime('%Y-%m-%dT%H.%M.%S', localtime(time()))))
+        filename = join(config.get('outdir'), '%s.%s.txt' % (slugify(ship), strftime('%Y-%m-%dT%H.%M.%S', localtime(time()))))
         with open(filename, 'wt') as h:
             h.write(string)
 


### PR DESCRIPTION
Fixes #303 

I could have left `slugify` in `monitor` and imported it from there intro `edshipyard`, but `loadout` also needed it and having either `monitor` or `loadout` reach into each other for a copy felt odd.

If you're in the mood for a more extensive clean-up, there's a lot of duplicate `filename = join(...)` code that could be extracted into `filenames` for the safety.