### PR TITLE
Update Error: Can't connect to EDDN

### DIFF
--- a/README.md
+++ b/README.md
@@ -167,7 +167,7 @@ EDMC supports this scenario if you run the second instance of E:D in a *differen
 EDMC doesn't support running two instances of E:D in the *same* user account. EDMC will only respond to the instance of E:D that you ran last.
 
 ### Error: Can't connect to EDDN
-EDMC needs to talk to eddn.edcd.io on port 4430. If you consistently receive this error check that your router or VPN configuration allows port 4430 / tcp outbound.
+EDMC needs to talk to eddn.edcd.io on port 4430. If you consistently receive this error check that your router or VPN configuration allows port 4430 / tcp outbound. Also running a proxy can lead to this error, try adding `eddn.edcd.io` to exemption list.
 
 ### Import failed: No ship loadout found
 Complex ship loadouts with Engineers' mods can cause you to hit an Internet Explorer / Edge limitation on the length of URLs. Switch to a browser that doesn't suck.


### PR DESCRIPTION
After an whole day of trying to find that error. Following SetUp:
Ubuntu box as router running dnsmasq + squid.
Windows 10 PC running ED:Market Connector.
Proxy settings inside Windows 10 set to the Ubuntu box.
Unable to connect to EDDN until `eddn.edcd.io` added to the exemption list in windows proxy settings.