### PR TITLE
Set the WM_CLASS Name of the Root Window

### DIFF
--- a/EDMarketConnector.py
+++ b/EDMarketConnector.py
@@ -801,6 +801,6 @@ if __name__ == "__main__":
 
     Translations.install(config.get('language') or None)	# Can generate errors so wait til log set up
 
-    root = tk.Tk()
+    root = tk.Tk(className=appname.lower())
     app = AppWindow(root)
     root.mainloop()


### PR DESCRIPTION
This allows manipulation of the main window by window managers & desktop
environments that can create rules based on window names/classes.

E.g., I have everything tiled by default so starting EDMC sizes it to the
entire space of my monitor. With this change, I can specify that the EDMC
window should be started as a floating window.

```bash
# Click the window after running
$ echo "WM_CLASS(STRING) = \"NAME\", \"CLASS\"" && xprop | grep "WM_CLASS"
WM_CLASS(STRING) = "NAME", "CLASS"
WM_CLASS(STRING) = "edmarketconnector", "Edmarketconnector"
```
