### PR TITLE
eddn cmdr_data not actually checking 'send to EDDN' option.

### DIFF
--- a/plugins/eddn.py
+++ b/plugins/eddn.py
@@ -470,7 +470,7 @@ def journal_entry(cmdr, is_beta, system, station, entry, state):
             return unicode(e)
 
 def cmdr_data(data, is_beta):
-    if data['commander'].get('docked') & config.getint('output') & config.OUT_MKT_EDDN:
+    if data['commander'].get('docked') and config.getint('output') & config.OUT_MKT_EDDN:
         try:
             if this.marketId != data['lastStarport']['id']:
                 this.commodities = this.outfitting = this.shipyard = None

--- a/plugins/eddn.py
+++ b/plugins/eddn.py
@@ -470,7 +470,7 @@ def journal_entry(cmdr, is_beta, system, station, entry, state):
             return unicode(e)
 
 def cmdr_data(data, is_beta):
-    if data['commander'].get('docked') & config.OUT_MKT_EDDN:
+    if data['commander'].get('docked') & config.getint('output') & config.OUT_MKT_EDDN:
         try:
             if this.marketId != data['lastStarport']['id']:
                 this.commodities = this.outfitting = this.shipyard = None


### PR DESCRIPTION
I was surprised to see errors from plugins/eddn.py during python3 porting when I thought I'd disabled the option in settings at the start of this work.  It turns out the check in the code was just whether config.OUT_MKT_EDDN was True, rather than if that option was currently set.