### PR TITLE
Ignore voicepacks in outfitting.py

### DIFF
--- a/outfitting.py
+++ b/outfitting.py
@@ -367,7 +367,7 @@ def lookup(module, ship_map, entitled=False):
         new['rating'] = 'I'
 
     # Skip uninteresting stuff - no longer present in ED 3.1 cAPI data
-    elif name[0] in ['bobble', 'decal', 'nameplate', 'paintjob', 'enginecustomisation', 'weaponcustomisation'] or name[1].startswith('shipkit') :
+    elif name[0] in ['bobble', 'decal', 'nameplate', 'paintjob', 'enginecustomisation', 'weaponcustomisation'] or name[1].startswith('shipkit') or name[0].startswith('voicepack'):
         return None
 
     # Shouldn't be listing player-specific paid stuff or broker/powerplay-specific modules in outfitting, other than Horizons


### PR DESCRIPTION
The default ship voicepack was causing errors with EDMC.py.  You might want to put the check elsewhere, but this seemed to be the best fit.